### PR TITLE
Renames k8s-render-demo to gifinator

### DIFF
--- a/gifcreator/gifcreator.go
+++ b/gifcreator/gifcreator.go
@@ -34,11 +34,11 @@ import (
 
 	"gopkg.in/redis.v5"
 
-	pb "github.com/GoogleCloudPlatform/k8s-render-demo/proto"
-	"github.com/GoogleCloudPlatform/k8s-render-demo/internal/gcsref"
+	pb "github.com/GoogleCloudPlatform/gifinator/proto"
+	"github.com/GoogleCloudPlatform/gifinator/internal/gcsref"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
-  "golang.org/x/image/font/gofont/gobold"
+	"golang.org/x/image/font/gofont/gobold"
 	"github.com/golang/freetype"
 	"github.com/bradfitz/slice"
 


### PR DESCRIPTION
Minor change to import to correct `make` errors:

```
$ make
go build -o frontend/frontend ./frontend
go build -o gifcreator/gifcreator ./gifcreator
gifcreator/gifcreator.go:38:2: cannot find package "github.com/GoogleCloudPlatform/k8s-render-demo/internal/gcsref" in any of:
...
```